### PR TITLE
Add the ability to pass flags and compiler version to godbolt.

### DIFF
--- a/src/godbolt.rs
+++ b/src/godbolt.rs
@@ -32,20 +32,45 @@ struct GodboltResponse {
     asm: GodboltOutput,
 }
 
+// Transforms human readable rustc version (e.g. "1.34.1") into compiler id on godbolt (e.g. "r1341")
+// Full list of version<->id can be obtained at https://godbolt.org/api/compilers/rust
+// Ideally we'd also check that the version exists, and give a nice error message if not, but eh.
+fn translate_rustc_version<'a>(
+    version: &'a str,
+) -> Result<std::borrow::Cow<'a, str>, crate::Error> {
+    if ["nightly", "beta"].contains(&version) {
+        return Ok(version.into());
+    }
+    // very crude sanity checking
+    if !version.chars().all(|c| c.is_digit(10) || c == '.') {
+        return Err(
+            "the `rustc` argument should be a version specifier. E.g. `nightly` `beta` or `1.45.2`"
+                .into(),
+        );
+    }
+    return Ok(format!("r{}", version.replace(".", "")).into());
+}
+
 /// Compile a given Rust source code file on Godbolt using the latest nightly compiler with
 /// full optimizations (-O3)
 /// Returns a multiline string with the pretty printed assembly
 fn compile_rust_source(
     http: &reqwest::blocking::Client,
     source_code: &str,
+    rustc: &str,
+    flags: &str,
 ) -> Result<Compilation, crate::Error> {
+    let rustc = translate_rustc_version(rustc)?;
     let response: GodboltResponse = http
         .execute(
-            http.post("https://godbolt.org/api/compiler/nightly/compile")
-                .query(&[("options", "-Copt-level=3 --edition=2018")])
-                .header(reqwest::header::ACCEPT, "application/json")
-                .body(source_code.to_owned())
-                .build()?,
+            http.post(&format!(
+                "https://godbolt.org/api/compiler/{}/compile",
+                rustc
+            ))
+            .query(&[("options", flags)])
+            .header(reqwest::header::ACCEPT, "application/json")
+            .body(source_code.to_owned())
+            .build()?,
         )?
         .json()?;
 
@@ -63,15 +88,26 @@ fn compile_rust_source(
 }
 
 pub fn godbolt(args: &crate::Args) -> Result<(), crate::Error> {
-    let (lang, text) = match compile_rust_source(args.http, crate::extract_code(&args.body)?)? {
-        Compilation::Success { asm, stderr } => ("x86asm", format!("{}\n{}", stderr, asm)),
-        Compilation::Error { stderr } => ("rust", stderr),
-    };
+    let rustc = args.params.get("rustc").unwrap_or(&"nightly");
+    let flags = args
+        .params
+        .get("flags")
+        .unwrap_or(&"-Copt-level=3 --edition=2018");
+    println!("r f = {:?} {:?}", rustc, flags);
+    let (lang, text, note) =
+        match compile_rust_source(args.http, crate::extract_code(&args.body)?, rustc, flags)? {
+            Compilation::Success { asm, stderr } => (
+                "x86asm",
+                asm,
+                (!stderr.is_empty()).then(|| "Note: compilation produced warnings\n"),
+            ),
+            Compilation::Error { stderr } => ("rust", stderr, None),
+        };
 
     crate::reply_potentially_long_text(
         args,
         &format!("```{}\n{}", lang, text),
-        "\n```",
+        &format!("\n```{}", note.unwrap_or("")),
         "Note: the output was truncated",
     )?;
 
@@ -81,11 +117,16 @@ pub fn godbolt(args: &crate::Args) -> Result<(), crate::Error> {
 pub fn help(args: &crate::Args) -> Result<(), crate::Error> {
     crate::api::send_reply(
         args,
-        "Compile Rust code using https://rust.godbolt.org. Full optimizations are applied.
-```?godbolt ``\u{200B}`
+        "Compile Rust code using https://rust.godbolt.org. Full optimizations are applied unless overriden.
+```?godbolt
+``\u{200B}`
 pub fn your_function() {
     // Code
 }
-``\u{200B}` ```",
+``\u{200B}` ```
+Optional arguments:
+    \t`flags`: flags to pass to rustc invocation. Defaults to `-Copt-level=3 --edition=2018`
+    \t`rustc`: compiler version to invoke. Defaults to `nightly`. Possible values: `nightly`, `beta` or full version like `1.45.2`
+",
     )
 }


### PR DESCRIPTION
Add the ability to pass flags and compiler version to godbolt.
Also, don't output warnings receieved from godbolt, if the code compiles at all
![20210303-034958-Discord](https://user-images.githubusercontent.com/7831163/109749992-8b480180-7bd3-11eb-887f-d3f319a2d843.png)