### PR TITLE
Add support for 2021 edition in code-running commands when possible

### DIFF
--- a/src/code_execution/playground/api.rs
+++ b/src/code_execution/playground/api.rs
@@ -67,6 +67,8 @@ pub enum Edition {
     E2015,
     #[serde(rename = "2018")]
     E2018,
+    #[serde(rename = "2021")]
+    E2021,
 }
 
 impl FromStr for Edition {
@@ -76,6 +78,7 @@ impl FromStr for Edition {
         match s {
             "2015" => Ok(Edition::E2015),
             "2018" => Ok(Edition::E2018),
+            "2021" => Ok(Edition::E2021),
             _ => Err(format!("invalid edition `{}`", s).into()),
         }
     }
@@ -151,6 +154,7 @@ pub fn url_from_gist(flags: &CommandFlags, gist_id: &str) -> String {
         match flags.edition {
             Edition::E2015 => "2015",
             Edition::E2018 => "2018",
+            Edition::E2021 => "2021",
         },
         gist_id
     )

--- a/src/code_execution/playground/play_eval.rs
+++ b/src/code_execution/playground/play_eval.rs
@@ -22,7 +22,12 @@ async fn play_or_eval(
         .post("https://play.rust-lang.org/execute")
         .json(&PlaygroundRequest {
             code: &code,
-            channel: flags.channel,
+            channel: if let Edition::E2021 = flags.edition {
+                // Edition 2021 only makes sense with nightly at the moment
+                Channel::Nightly
+            } else {
+                flags.channel
+            },
             crate_type: if code.contains("fn main") {
                 CrateType::Binary
             } else {

--- a/src/code_execution/playground/util.rs
+++ b/src/code_execution/playground/util.rs
@@ -89,7 +89,7 @@ pub fn generic_help(spec: GenericHelp<'_>) -> String {
         reply += "- mode: debug, release (default: debug)\n";
         reply += "- channel: stable, beta, nightly (default: nightly)\n";
     }
-    reply += "- edition: 2015, 2018 (default: 2018)\n";
+    reply += "- edition: 2015, 2018, 2021 (default: 2018)\n";
     if spec.warn {
         reply += "- warn: true, false (default: false)\n";
     }
@@ -262,6 +262,8 @@ pub fn apply_rustfmt(text: &str, edition: api::Edition) -> Result<api::PlayResul
             match edition {
                 api::Edition::E2015 => "2015",
                 api::Edition::E2018 => "2018",
+                // Fallback to 2018 edition when 2021 was specified since `rustfmt` does not support it yet
+                api::Edition::E2021 => "2018",
             },
             "--color",
             "never",


### PR DESCRIPTION
The rust playground recently added support for the 2021 edition.
This PR allows users to specify `edition=2021` for commands where it was already possible to specify editions.

There is one catch though: that edition only works with the nightly channel. 
The PR currently falls back to `channel=nightly` if the user specified `edition=2021`. 
I don't know how good of a behavior that is. Maybe it's fine but maybe we could also send an extra notice to the user saying we ignored its `channel=stable` or `channel=beta` request whenever they specified `edition=2021` . I'll let you decide 🥰 

Anyway, here is a screenshot to validate the feature:
![image](https://user-images.githubusercontent.com/2079561/124385069-835cb300-dcd4-11eb-9042-40804dd109e7.png)
