### PR TITLE
Clarify some parts of bot set-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ SHOWCASE_CHANNEL_ID=
 REPORTS_CHANNEL_ID=
 
 # File name of the database
-DATABASE_URL=sqlite:database/database.sqlite
+DATABASE_URL=sqlite:database.sqlite
 
 # Whether to enable experimental user-specific custom prefixes
 # Experimental because I haven't yet tested the performance impact of issuing an SQLite query on

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ SHOWCASE_CHANNEL_ID=
 # `/report` command
 REPORTS_CHANNEL_ID=
 
+# If running the bot for the first time, set to `true`
+# otherwise, sqlx will error at compile-time if the database hasn't been set-up yet.
+SQLX_OFFLINE=
+
 # File name of the database
 DATABASE_URL=sqlite:database.sqlite
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.env
+/database
 /database.sqlite*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Adjust the client_id in the URL for your own hosted instances of the bot.
 
 ## Hosting the bot
 
+The bot requires `Server Members Intent` enabled in the `Applications > $YOUR_BOTS_NAME > Bot`
+settings of Discord's [developer portal](https://discord.com/developers/applications).
+
 Run the bot using `cargo run --release`.
 
 You will need to provide several environment variables. A convenient way to do this is to copy the


### PR DESCRIPTION
- mention `SQLX_OFFLINE` in `.env.example` too, since one might prefer to set it in their `.env`
- Currently if someone does not manually create a `database` directory (like the dockerfile does) and uses whats already listed in `DATABASE_URL`, the bot will error at runtime with `error returned from database: unable to open database file` since it does not automatically create the missing directory for the user. The previous gitignore already expects the database to be created in the root of the project with `cargo run`, so we make that the default in the example .env.
- added `/database` to the gitignore if someone does decide they don't want to pollute the root folder.
- mention the required discord intent in the readme or else the bot errors with `ERROR serenity::gateway::shard] [Shard [0, 1]] Disallowed gateway intents have been provided.`
