### PR TITLE
Add `?revision`: displays git revision the bot was built against

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    if let Some(rev) = rev_parse() {
+        println!("cargo:rustc-env=RUSTBOT_REV={}", rev);
+    }
+}
+
+/// Retrieves SHA-1 git revision. Returns `None` if any step of the way fails,
+/// since this is only nice to have for the ?revision command and shouldn't fail builds.
+fn rev_parse() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(&["rev-parse", "--short=9", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,7 @@ async fn app() -> Result<(), Error> {
     options.command(misc::register(), |f| f.category("Miscellaneous"));
     options.command(misc::uptime(), |f| f.category("Miscellaneous"));
     options.command(misc::servers(), |f| f.category("Miscellaneous"));
+    options.command(misc::revision(), |f| f.category("Miscellaneous"));
     if custom_prefixes {
         options.command(prefixes::prefix(), |f| {
             f.category("Miscellaneous")

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -71,3 +71,11 @@ pub async fn servers(ctx: Context<'_>) -> Result<(), Error> {
 
     Ok(())
 }
+
+/// Displays the SHA-1 git revision the bot was built against
+#[poise::command(prefix_command, hide_in_help, discard_spare_arguments)]
+pub async fn revision(ctx: Context<'_>) -> Result<(), Error> {
+    let rustbot_rev: Option<&'static str> = option_env!("RUSTBOT_REV");
+    poise::say_reply(ctx, format!("`{}`", rustbot_rev.unwrap_or("unknown"))).await?;
+    Ok(())
+}


### PR DESCRIPTION
This can be helpful if one wants to query what was last built locally or how far behind the bot is from upstream.
![image](https://user-images.githubusercontent.com/6868531/137409153-f700a775-8205-4c7f-a950-ed8192a529fc.png)
