### PR TITLE
Lock the report thread, so that it's only unarchivable by mods

### DIFF
--- a/src/moderation/mod.rs
+++ b/src/moderation/mod.rs
@@ -177,6 +177,10 @@ pub async fn report(
         // .create_public_thread(ctx.discord(), msg, |b| b.name(report_name))
         .create_private_thread(ctx.discord(), |b| b.name(report_name))
         .await?;
+    // Prevent non-mods from unarchiving the thread and accidentally exposing themselves in audit log.
+    report_thread
+        .edit_thread(ctx.discord(), |t| t.locked(true))
+        .await?;
 
     let thread_message_content = format!(
         "Hey <@&{}>, <@{}> sent a report from channel {}: {}\n> {}",


### PR DESCRIPTION
Unarchiving a thread shows the unarchiver in the audit log, which leads to identity leak if (accidentally?) performed by a user.
While there is seldom a reason to unarchive the report thread, so this situation is fairly rare, it is still nice to programmatically enforce this kind of problem never arises.